### PR TITLE
docs: vlc config update

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -27,7 +27,7 @@ Some music players require additional configuration to support audio processing.
 ## VLC
 - Select the 'More' tab in the bottom navigation
 - Press Settings in the top left corner
-- Under extra settings, press 'Audio' - Audio output
+- Under Extra settings, press 'Advanced' - scroll to Performance - press 'Audio output'
 - Select AudioTrack
 
 This list is exhaustive. Suggestions are welcome.


### PR DESCRIPTION
Summary:
Updated the VLC configuration steps in configuration.md to line up with the settings layout in the current VLC app (v3.7.0).

Reason for the change:
VLC audio output setting has moved from Audio to Advanced.

Change:
Replaced Step 3
- Under Extra settings, press 'Advanced' - scroll to Performance - press 'Audio output'

Notes:
Nothing was changed unless explicitly mentioned above.